### PR TITLE
Use build-arg rather than perl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,7 @@ endif
 	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\
 	docker tag $(REPO)/omero-web:latest $(REPO)/omero-web:$$MAJOR_MINOR
 
-	perl -i -pe 's%FROM\s.+%FROM $(REPO)/omero-web:latest%' standalone/Dockerfile
-
-	docker build -t $(REPO)/omero-web-standalone:latest standalone
+	docker build --build-arg=PARENT_IMAGE=$(REPO)/omero-web:$(VERSION) -t $(REPO)/omero-web-standalone:latest standalone
 	docker tag $(REPO)/omero-web-standalone:latest $(REPO)/omero-web-standalone:$(VERSION)-$(BUILD)
 	docker tag $(REPO)/omero-web-standalone:latest $(REPO)/omero-web-standalone:$(VERSION)
 	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -1,4 +1,5 @@
-FROM openmicroscopy/omero-web:latest
+ARG PARENT_IMAGE=openmicroscopy/omero-web:latest
+FROM ${PARENT_IMAGE}
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 USER root


### PR DESCRIPTION
When testing this, I got a local diff which hard-coded by parent image to "test/web:latest" which might be confusing. This proposes using build-args.

I was also having issues using VERISON=jtest. It's not being propagated to test_getweb.sh but that may be a mistake on my side.